### PR TITLE
Add machine readable license information

### DIFF
--- a/PackageInfo.in.g
+++ b/PackageInfo.in.g
@@ -19,6 +19,9 @@ Version := "IRREDSOL_VERSION",
 ##  Release date of the current version in dd/mm/yyyy format.
 Date := "IRREDSOL_DATE",
 
+##  Machine readable license information (as an SPDX identifier)
+License := "BSD-2-Clause",
+
 BannerString := "\
 ----------------------------------------------------------------------\n\
                           IRREDSOL Version IRREDSOL_VERSION\n\


### PR DESCRIPTION
This information is e.g. used when generating the package pages on the GAP homepage, and also downstream distributors (such as typical Linux distributions, e.g. Debian, Fedora, ...) appreciate having this information readily available.