### PR TITLE
Remove superfluous DegreeOfMatrixGroup method

### DIFF
--- a/lib/matmeths.gi
+++ b/lib/matmeths.gi
@@ -27,11 +27,6 @@ InstallMethod(DegreeOfMatrixGroup, "for matrix group with dimension", true,
     Dimension);
 
 
-InstallMethod(DegreeOfMatrixGroup, "for matrix group with dimension", true, 
-    [IsMatrixGroup and HasDimensionOfMatrixGroup], 0,
-    DimensionOfMatrixGroup);
-
-
 ############################################################################
 ##
 #M  IsIrreducible(<G>)


### PR DESCRIPTION
DegreeOfMatrixGroup is a synonym for DimensionOfMatrixGroup -- that means they
are actually identical. Installing an operation as a method for itself will cause a segfault
if that method ever is invoked Luckily, for attribute storing reps (which currently is used
by all our matrix groups), that method never gets invoked anyway precisely because the
two attributes are identical: if HasDimensionOfMatrixGroup(G) gives true, then the system
getter (which has a very high rank) is used to retrieve the value.

Still, it seems best to remove this. Future GAP versions will likely warn or even produce an
error if one tries to install an operation as a method (see https://github.com/gap-system/gap/issues/4340 and https://github.com/gap-system/gap/issues/1286).