### PR TITLE
Only declare DegreeOfMatrixGroup if it is missing

### DIFF
--- a/lib/matmeths.gd
+++ b/lib/matmeths.gd
@@ -55,13 +55,12 @@ DeclareOperation("IsPrimitive", [IsMatrixGroup, IsField]);
 ##
 ##  see IRREDSOL documentation
 ##  
-IRREDSOL_tmp := InfoLevel(InfoDebug);
-SetInfoLevel(InfoDebug, 0); # suppress DeclareSynonym warning
-
-DeclareSynonymAttr("DegreeOfMatrixGroup", DimensionOfMatrixGroup);
+if not IsBound(DegreeOfMatrixGroup) then
+    # DegreeOfMatrixGroup is also declared identically in primgrp, so to
+    # avoid warnings we only define it if necessary
+    DeclareSynonymAttr("DegreeOfMatrixGroup", DimensionOfMatrixGroup);
+fi;
 DECLARE_IRREDSOL_SYNONYMS_ATTR("DegreeOfMatrixGroup");
-
-SetInfoLevel(InfoDebug,IRREDSOL_tmp);
 
 
 ############################################################################


### PR DESCRIPTION
This is arguably cleaner than turning off debug info messages temporarily.

I've submitted a symmetric change to primgrp, see https://github.com/gap-packages/primgrp/pull/42, so that these two packages can be loaded in either order without producing a warning about this double declaration.