### PR TITLE
Fix references to the primgrp manual

### DIFF
--- a/doc/recognition.tex
+++ b/doc/recognition.tex
@@ -158,7 +158,7 @@ allow one to translate between between that library and the {\IRREDSOL} library.
 \>IdIrreducibleSolubleMatrixGroupIndexMS(<n>, <p>, <k>) F
 
 This function returns the id (see "IdIrreducibleSolubleMatrixGroup") of <G>, 
-where <G> is `IrreducibleSolubleGroupMS'(<n>, <p>, <k>) (see {\PrimGrp} reference manual "primgrp:`IrreducibleSolvableGroupMS'") .
+where <G> is `IrreducibleSolubleGroupMS'(<n>, <p>, <k>) (see {\PrimGrp} reference manual "primgrp:IrreducibleSolvableGroupMS") .
 
 \beginexample
 gap> IdIrreducibleSolubleMatrixGroupIndexMS(6, 2, 5);
@@ -178,7 +178,7 @@ true
 \>IndexMSIdIrreducibleSolubleMatrixGroup(<n>, <q>, <d>, <k>) F
 
 This function returns a triple [<n>, <p>, <l>] such that
-`IrreducibleSolubleGroupMS'(<n>, <p>, <l>) (see {\PrimGrp}  reference manual  "primgrp:`IrreducibleSolvableGroupMS'") is conjugate to
+`IrreducibleSolubleGroupMS'(<n>, <p>, <l>) (see {\PrimGrp} reference manual "primgrp:IrreducibleSolvableGroupMS") is conjugate to
 `IrreducibleSolubleMatrixGroup'(<n>, <q>, <d>, <k>) (see "IrreducibleSolubleMatrixGroup").
 
 \beginexample


### PR DESCRIPTION
Fixes these errors during documentation build:
```
1. Overview ... overview.tex
2. Accessing the data library ... access.tex
3. Recognition of matrix groups ... recognition.tex
Bad link: "primgrp:`IrreducibleSolvableGroupMS'" at line 161 of recognition.tex
Bad link: "primgrp:`IrreducibleSolvableGroupMS'" at line 181 of recognition.tex
```
