### PR TITLE
doc: remove Dimension for matrix groups

### DIFF
--- a/doc/matgroups.tex
+++ b/doc/matgroups.tex
@@ -25,7 +25,6 @@ attributes.
 \>DegreeOfMatrixGroup(<G>) A
 \>Degree(<G>)!{for matrix groups} O
 \>DimensionOfMatrixGroup(<G>) A
-\>Dimension(<G>)!{for matrix groups} A
 
 This is the degree of the matrix group or, equivalently, the dimension of the
 natural underlying vector space. See also "ref:DimensionOfMatrixGroup".


### PR DESCRIPTION
It does not actually exist (anymore?)
